### PR TITLE
match function rename in sapp-jsutils

### DIFF
--- a/js/demo.js
+++ b/js/demo.js
@@ -23,5 +23,5 @@ function perform_demo() {
   // call rust function returning a string
   var rust_object = wasm_exports.get_demo_string();
 
-  console.log(from_js_object(rust_object)); // ensure that this is a string
+  console.log(consume_js_object(rust_object)); // ensure that this is a string
 };


### PR DESCRIPTION
Thanks for making macroquad! 

I ran into an error while looking up how to do js interop. It looks like 'from_js_object' was renamed 'consume_js_object' (which makes sense).